### PR TITLE
Add v1.11 map versions

### DIFF
--- a/lobbies.py
+++ b/lobbies.py
@@ -13,6 +13,15 @@ class MapVersion:
         self.slots = slots
 
 KNOWN_VERSIONS = [
+    MapVersion("Impossible.Bosses.v1.11.6"),
+    MapVersion("Impossible.Bosses.v1.11.6-no-bnet", ent_only=True),
+    MapVersion("Impossible.Bosses.v1.11.5-no-bnet", ent_only=True, deprecated=True),
+    MapVersion("Impossible.Bosses.v1.11.4-nobnet", ent_only=True, deprecated=True),
+    MapVersion("Impossible.Bosses.v1.11.3-ent", ent_only=True, deprecated=True),
+    MapVersion("Impossible.Bosses.v1.11.2-ent", ent_only=True, deprecated=True),
+    MapVersion("Impossible.Bosses.v1.11.1-ent", ent_only=True, deprecated=True),
+    MapVersion("Impossible.Bosses.v1.11.0-ent", ent_only=True, deprecated=True),
+
     MapVersion("Impossible.Bosses.v1.10.5"),
     MapVersion("Impossible.Bosses.v1.10.5-ent", ent_only=True),
     MapVersion("Impossible.Bosses.v1.10.4-ent", ent_only=True, deprecated=True),

--- a/main.py
+++ b/main.py
@@ -827,8 +827,15 @@ class MapVersion:
         self.slots = slots
 
 KNOWN_VERSIONS = [
-    MapVersion("Impossible.Bosses.v1.10.5"),
-    MapVersion("Impossible.Bosses.v1.10.5-ent", ent_only=True),
+    # TODO will keep updating until Battle.Net version release
+    MapVersion("Impossible.Bosses.v1.11.3"),
+    MapVersion("Impossible.Bosses.v1.11.3-ent", ent_only=True),
+    MapVersion("Impossible.Bosses.v1.11.2-ent", ent_only=True, deprecated=True),
+    MapVersion("Impossible.Bosses.v1.11.1-ent", ent_only=True, deprecated=True),
+    MapVersion("Impossible.Bosses.v1.11.0-ent", ent_only=True, deprecated=True),
+
+    MapVersion("Impossible.Bosses.v1.10.5", deprecated=True),
+    MapVersion("Impossible.Bosses.v1.10.5-ent", ent_only=True, deprecated=True),
     MapVersion("Impossible.Bosses.v1.10.4-ent", ent_only=True, deprecated=True),
     MapVersion("Impossible.Bosses.v1.10.3-ent", ent_only=True, deprecated=True),
     MapVersion("Impossible.Bosses.v1.10.2-ent", ent_only=True, deprecated=True),


### PR DESCRIPTION
I will keep updating this PR until we do the official battle.net release for v1.11, which I expect to be either `v1.11.3` or `v1.11.4`.

EDIT: LOL such naive expectations... it's `v1.11.6`... will update soon.