### PR TITLE
MMD parsing, nice replay post, and moving some code around

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,25 @@
+name: verify
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  verify:
+    runs-on: [self-hosted]
+    timeout-minutes: 5
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Python Requirements
+        run: python3 -m pip install -r ./requirements.txt
+
+      - name: pytest
+        run: python3 -m pytest

--- a/lobbies.py
+++ b/lobbies.py
@@ -1,0 +1,185 @@
+import discord
+import logging
+
+BELL_EMOJI = "\U0001F514"
+NOBELL_EMOJI = "\U0001F515"
+
+class MapVersion:
+    def __init__(self, file_name, ent_only=False, deprecated=False, counterfeit=False, slots=[8,11]):
+        self.file_name = file_name
+        self.ent_only = ent_only
+        self.deprecated = deprecated
+        self.counterfeit = counterfeit
+        self.slots = slots
+
+KNOWN_VERSIONS = [
+    MapVersion("Impossible.Bosses.v1.10.5"),
+    MapVersion("Impossible.Bosses.v1.10.5-ent", ent_only=True),
+    MapVersion("Impossible.Bosses.v1.10.4-ent", ent_only=True, deprecated=True),
+    MapVersion("Impossible.Bosses.v1.10.3-ent", ent_only=True, deprecated=True),
+    MapVersion("Impossible.Bosses.v1.10.2-ent", ent_only=True, deprecated=True),
+    MapVersion("Impossible.Bosses.v1.10.1-ent", ent_only=True, deprecated=True),
+
+    MapVersion("Impossible_BossesReforgedV1.09Test", deprecated=True),
+    MapVersion("ImpossibleBossesEnt1.09", ent_only=True, deprecated=True),
+    MapVersion("Impossible_BossesReforgedV1.09_UFWContinues", counterfeit=True),
+    MapVersion("Impossible_BossesReforgedV1.09UFW30", counterfeit=True),
+    MapVersion("Impossible_BossesReforgedV1.08Test", deprecated=True),
+    MapVersion("Impossible_BossesReforgedV1.07Test", deprecated=True),
+    MapVersion("Impossible_BossesTestversion1.06", deprecated=True),
+    MapVersion("Impossible_BossesReforgedV1.05", deprecated=True),
+    MapVersion("Impossible_BossesReforgedV1.02", deprecated=True),
+
+    MapVersion("Impossible Bosses BetaV3V", deprecated=True),
+    MapVersion("Impossible Bosses BetaV3R", deprecated=True),
+    MapVersion("Impossible Bosses BetaV3P", deprecated=True),
+    MapVersion("Impossible Bosses BetaV3E", deprecated=True),
+    MapVersion("Impossible Bosses BetaV3C", deprecated=True),
+    MapVersion("Impossible Bosses BetaV3A", deprecated=True),
+    MapVersion("Impossible Bosses BetaV2X", deprecated=True),
+    MapVersion("Impossible Bosses BetaV2W", deprecated=True),
+    MapVersion("Impossible Bosses BetaV2S", deprecated=True),
+    MapVersion("Impossible Bosses BetaV2J", deprecated=True),
+    MapVersion("Impossible Bosses BetaV2F", deprecated=True),
+    MapVersion("Impossible Bosses BetaV2E", deprecated=True),
+    MapVersion("Impossible Bosses BetaV2D", deprecated=True),
+    MapVersion("Impossible Bosses BetaV2C", deprecated=True),
+    MapVersion("Impossible Bosses BetaV2A", deprecated=True),
+    MapVersion("Impossible Bosses BetaV1Y", deprecated=True),
+    MapVersion("Impossible Bosses BetaV1X", deprecated=True),
+    MapVersion("Impossible Bosses BetaV1W", deprecated=True),
+    MapVersion("Impossible Bosses BetaV1V", deprecated=True),
+    MapVersion("Impossible Bosses BetaV1R", deprecated=True),
+    MapVersion("Impossible Bosses BetaV1P", deprecated=True),
+    MapVersion("Impossible Bosses BetaV1C", deprecated=True),
+]
+
+def get_map_version(map_file):
+    for version in KNOWN_VERSIONS:
+        if map_file == version.file_name:
+            return version
+    return None
+
+def get_map_server_nice(server):
+    if server == "usw":
+        return ":flag_us: US"
+    elif server == "eu":
+        return ":flag_eu: EU"
+    elif server == "kr":
+        return ":flag_kr: KR"
+    elif server == "Montreal":
+        return ":flag_ca: Montreal (ENT)"
+    elif server == "New York":
+        return ":flag_us: New York (ENT)"
+    elif server == "France":
+        return ":flag_fr: France (ENT)"
+    elif server == "Amsterdam":
+        return ":flag_nl: Amsterdam (ENT)"
+    return server
+
+class Lobby:
+    def __init__(self, lobby_dict, is_ent):
+        self.is_ent = is_ent
+        self.id = lobby_dict["id"]
+        self.name = lobby_dict["name"]
+        self.map = lobby_dict["map"]
+        self.host = lobby_dict["host"]
+        self.subscribers = []
+
+        if is_ent:
+            self.server = lobby_dict["location"]
+            self.slots_taken = lobby_dict["slots_taken"]
+            self.slots_total = lobby_dict["slots_total"]
+        else:
+            if self.map[-4:] == ".w3x":
+                self.map = self.map[:-4]
+            self.server = lobby_dict["server"]
+            self.slots_taken = lobby_dict["slotsTaken"]
+            self.slots_total = lobby_dict["slotsTotal"]
+
+    def __eq__(self, other):
+        return self.id == other.id
+
+    def __hash__(self):
+        return self.id
+
+    def __str__(self):
+        return "[id={} ent={} name=\"{}\" server={} map=\"{}\" host={} slots={}/{}]".format(
+            self.id, self.is_ent, self.name, self.server, self.map, self.host, self.slots_taken, self.slots_total
+        )
+
+    def get_message_id_key(self):
+        return "lobbymsg{}".format(self.id)
+
+    def is_ib(self):
+        return self.map.find("Legion") != -1 and self.map.find("TD") != -1 # test
+        #return self.map.find("Uther Party") != -1 # test
+        return self.map.find("Impossible") != -1 and self.map.find("Bosses") != -1
+
+    def is_updated(self, new):
+        return self.name != new.name or self.server != new.server or self.map != new.map or self.host != new.host or self.slots_taken != new.slots_taken or self.slots_total != new.slots_total
+
+    def to_discord_message_info(self, is_open=True):
+        COLOR_CLOSED = discord.Colour(0x8a0808)
+
+        version = get_map_version(self.map)
+        mark = ""
+        message = ""
+        if version is None:
+            mark = ":question:"
+            message = ":warning: *WARNING: Unknown map version* :warning:"
+        elif version.counterfeit:
+            mark = ":x:"
+            message = ":warning: *WARNING: Counterfeit version* :warning:"
+        elif not self.is_ent and version.ent_only:
+            mark = ":x:"
+            message = ":warning: *WARNING: Incompatible version* :warning:"
+        elif version.deprecated:
+            mark = ":x:"
+            message = ":warning: *WARNING: Old map version* :warning:"
+
+        slots_taken = self.slots_taken
+        slots_total = self.slots_total
+
+        if version is not None:
+            if not self.is_ent:
+                # Not sure why, but IB bnet lobbies have 1 extra slot
+                slots_taken -= 1
+                slots_total -= 1
+
+            if slots_total not in version.slots:
+                logging.error("Invalid total slots {}, expected {}, for map file {}".format(self.slots_total, version.slots, self.map))
+                return None
+
+        title_format = "{} ({}/{})"
+        description_format = "{} {}"
+        if not is_open:
+            title_format = "~~{}~~ ({}/{})"
+            description_format = "~~{}~~ {}"
+
+        title = title_format.format(self.name, slots_taken, slots_total)
+        description = description_format.format(self.map, mark)
+        host = self.host if len(self.host) > 0 else "---"
+        server = get_map_server_nice(self.server)
+
+        embed = discord.Embed(title=title, description=description)
+        embed.add_field(name="Host", value=host, inline=True)
+        embed.add_field(name="Server", value=server, inline=True)
+        if len(self.subscribers) > 0:
+            subscribers_string = BELL_EMOJI + " "
+            for i in range(0, len(self.subscribers), 4):
+                if i != 0:
+                    subscribers_string += "\n"
+                subscribers_string += ", ".join([
+                    sub.display_name for sub in self.subscribers[i:i+4]
+                ])
+
+            embed.set_footer(text=subscribers_string)
+
+        if not is_open:
+            embed.color = COLOR_CLOSED
+
+        return {
+            "message": message,
+            "embed": embed,
+        }

--- a/lobbies.py
+++ b/lobbies.py
@@ -112,7 +112,7 @@ class Lobby:
         return "lobbymsg{}".format(self.id)
 
     def is_ib(self):
-        return self.map.find("Legion") != -1 and self.map.find("TD") != -1 # test
+        #return self.map.find("Legion") != -1 and self.map.find("TD") != -1 # test
         #return self.map.find("Uther Party") != -1 # test
         return self.map.find("Impossible") != -1 and self.map.find("Bosses") != -1
 

--- a/lobbies.py
+++ b/lobbies.py
@@ -127,16 +127,16 @@ class Lobby:
         message = ""
         if version is None:
             mark = ":question:"
-            message = ":warning: *WARNING: Unknown map version* :warning:"
+            message = ":warning: *Unknown map version* :warning:"
         elif version.counterfeit:
             mark = ":x:"
-            message = ":warning: *WARNING: Counterfeit version* :warning:"
+            message = ":warning: *Counterfeit version* :warning:"
         elif not self.is_ent and version.ent_only:
             mark = ":x:"
-            message = ":warning: *WARNING: Incompatible version* :warning:"
+            message = ":warning: *Incompatible version* :warning:"
         elif version.deprecated:
             mark = ":x:"
-            message = ":warning: *WARNING: Old map version* :warning:"
+            message = ":warning: *Old map version* :warning:"
 
         slots_taken = self.slots_taken
         slots_total = self.slots_total

--- a/main.py
+++ b/main.py
@@ -8,15 +8,14 @@ from enum import Enum, unique
 import functools
 import git
 import io
+import json
 import logging
 import os
+import params
 import pickle
 import sqlite3
 import sys
 import traceback
-import requests
-import params
-import json
 
 from lobbies import Lobby, BELL_EMOJI, NOBELL_EMOJI
 from replays import ReplayData, replays_load_emojis

--- a/main.py
+++ b/main.py
@@ -874,10 +874,12 @@ async def check_replay(message):
     replay = await att.read()
     timeout = aiohttp.ClientTimeout(total=ENSURE_DISPLAY_WINDOW)
     async with aiohttp.ClientSession(timeout=timeout) as session:
+        logging.info("Uploading replay {}".format(att.filename))
         response = await session.post("https://api.wc3stats.com/upload", data={
             "file": replay
         })
         if response.status != 200:
+            logging.error("Replay upload failed")
             logging.error(await response.text())
             await ensure_display(message.channel.send, "Failed to upload replay `{}` with status `{}`".format(att.filename, response.status), window=ENSURE_DISPLAY_WINDOW)
             return

--- a/main.py
+++ b/main.py
@@ -1096,7 +1096,7 @@ async def update_bnet_lobbies(session, prev_lobbies):
 
     lobbies = [Lobby(obj, is_ent=False) for obj in body]
     ib_lobbies = [lobby for lobby in lobbies if lobby.is_ib()]
-    logging.info("wc3stats: {}/{} IB lobbies".format(len(ib_lobbies), len(lobbies)))
+    logging.debug("wc3stats: {}/{} IB lobbies".format(len(ib_lobbies), len(lobbies)))
     return await report_lobbies(prev_lobbies, ib_lobbies)
 
 async def update_ent_lobbies(session, prev_lobbies):
@@ -1107,7 +1107,7 @@ async def update_ent_lobbies(session, prev_lobbies):
 
     lobbies = [Lobby(obj, is_ent=True) for obj in response_json]
     ib_lobbies = [lobby for lobby in lobbies if lobby.is_ib()]
-    logging.info("ENT: {}/{} IB lobbies".format(len(ib_lobbies), len(lobbies)))
+    logging.debug("ENT: {}/{} IB lobbies".format(len(ib_lobbies), len(lobbies)))
     return await report_lobbies(prev_lobbies, ib_lobbies)
 
 async def update_ib_lobbies():
@@ -1185,7 +1185,7 @@ async def refresh_ib_lobbies():
     if not _initialized:
         return
 
-    logging.info("Refreshing lobby list")
+    logging.debug("Refreshing lobby list")
     async with _update_lobbies_lock:
         await update_ib_lobbies()
 

--- a/main.py
+++ b/main.py
@@ -37,6 +37,7 @@ def get_source_version():
         raise Exception("HEAD commit sha not found: {}".format(repo.head.commit.hexsha))
     return total - index
 
+@unique
 class MessageType(Enum):
     CONNECT = "connect"
     CONNECT_ACK = "connectack"

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ import datetime
 import discord
 from discord.ext.tasks import loop
 from discord.ext import commands
-from enum import Enum, auto
+from enum import Enum, unique
 import functools
 import git
 import io
@@ -17,6 +17,9 @@ import traceback
 import requests
 import params
 import json
+
+from lobbies import Lobby, BELL_EMOJI, NOBELL_EMOJI
+from replays import ReplayData
 
 ROOT_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -505,9 +508,6 @@ async def on_message(message):
                 attachment = message.attachments[0]
             await parse_bot_com(from_id, message_type, content, attachment)
     else:
-        # TODO temporary
-        if message.content == "!getgames":
-            await do_getgames(message.channel, message)
         await check_replay(message)
         await _client.process_commands(message)
 
@@ -860,27 +860,34 @@ async def pedigree(ctx):
 # ==== MISC ========================================================================================
 
 async def check_replay(message):
-    att = message.attachments
-    if len(att) > 0 :
-        if ".w3g" in att[0].filename:
-            replay = await att[0].read()
-            r = await post_replay(replay)
-            if r.status_code == 200:
-                replay_response = json.loads(r.text)
-                await ensure_display(message.channel.send, "Replay `"+ att[0].filename +"` sent => https://wc3stats.com/games/" + str(replay_response['body']['id']))
-            else:
-                await ensure_display(message.channel.send, "Replay `"+ att[0].filename +"` sent : " + str(r.status_code))
+    if len(message.attachments) == 0:
+        return
 
-async def post_replay(replay):
-    #replay = open("replay.w3g", "rb")
-    file_dic = {
-        "file": replay,
-    } 
-    return requests.post("https://api.wc3stats.com/upload", files=file_dic)
+    att = message.attachments[0]
+    if ".w3g" not in att.filename:
+        return
+
+    replay = await att.read()
+    timeout = aiohttp.ClientTimeout(total=60)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        response = await session.post("https://api.wc3stats.com/upload", data=replay)
+        if response.status_code != 200:
+            await ensure_display(message.channel.send, "Failed to upload replay \"{}\" with status {}".format(att.filename, response.status_code))
+            return
+
+        response_json = await response.json()
+        replay_id = response_json["body"]["id"]
+        response_get = await session.get("https://api.wc3stats.com/replays/" + replay_id)
+        if response_get.status_code != 200:
+            await ensure_display(message.channel.send, "Uploaded replay \"{}\" => https://wc3stats.com/games/{}".format(att.filename, replay_id))
+            return
+
+        response_get_json = await response_get.json()
+        game_data = ReplayData(response_get_json)
 
 @_client.command()
-async def unsub(ctx,arg1 = None):
-    await ensure_display(functools.partial(unsub2,ctx,arg1))
+async def unsub(ctx, arg1=None):
+    await ensure_display(functools.partial(unsub2, ctx, arg1))
     
 async def unsub2(ctx,arg1):
     if (arg1 == "EU" or arg1 == "eu"):
@@ -894,10 +901,10 @@ async def unsub2(ctx,arg1):
         await ctx.message.channel.send("KR has been succesfully removed from your roles")
 
 @_client.command()
-async def sub(ctx,arg1 = None):
-    await ensure_display(functools.partial(sub2,ctx,arg1))
+async def sub(ctx, arg1=None):
+    await ensure_display(functools.partial(sub2, ctx, arg1))
     
-async def sub2(ctx,arg1):
+async def sub2(ctx, arg1):
     if (arg1 == "EU" or arg1 == "eu"):
         await ctx.message.author.add_roles(_EU_role)
         await ctx.message.channel.send("EU has been succesfully added in your roles")
@@ -948,277 +955,95 @@ async def sub2(ctx,arg1):
 LOBBY_REFRESH_RATE = 5
 QUERY_RETRIES_BEFORE_WARNING = 10
 ENSURE_DISPLAY_WINDOW = LOBBY_REFRESH_RATE * 2
-BELL_EMOJI = "\U0001F514"
-NOBELL_EMOJI = "\U0001F515"
 
 _update_lobbies_lock = asyncio.Lock()
 
-class MapVersion:
-    def __init__(self, file_name, ent_only=False, deprecated=False, counterfeit=False, slots=[8,11]):
-        self.file_name = file_name
-        self.ent_only = ent_only
-        self.deprecated = deprecated
-        self.counterfeit = counterfeit
-        self.slots = slots
+def lobby_get_message_id(lobby):
+    key = lobby.get_message_id_key()
+    if key not in globals():
+        return None
+    return globals()[key]
 
-KNOWN_VERSIONS = [
-    MapVersion("Impossible.Bosses.v1.10.5"),
-    MapVersion("Impossible.Bosses.v1.10.5-ent", ent_only=True),
-    MapVersion("Impossible.Bosses.v1.10.4-ent", ent_only=True, deprecated=True),
-    MapVersion("Impossible.Bosses.v1.10.3-ent", ent_only=True, deprecated=True),
-    MapVersion("Impossible.Bosses.v1.10.2-ent", ent_only=True, deprecated=True),
-    MapVersion("Impossible.Bosses.v1.10.1-ent", ent_only=True, deprecated=True),
+async def lobby_create_message(lobby):
+    channel = _ent_channel if lobby.is_ent else _bnet_channel
 
-    MapVersion("Impossible_BossesReforgedV1.09Test", deprecated=True),
-    MapVersion("ImpossibleBossesEnt1.09", ent_only=True, deprecated=True),
-    MapVersion("Impossible_BossesReforgedV1.09_UFWContinues", counterfeit=True),
-    MapVersion("Impossible_BossesReforgedV1.09UFW30", counterfeit=True),
-    MapVersion("Impossible_BossesReforgedV1.08Test", deprecated=True),
-    MapVersion("Impossible_BossesReforgedV1.07Test", deprecated=True),
-    MapVersion("Impossible_BossesTestversion1.06", deprecated=True),
-    MapVersion("Impossible_BossesReforgedV1.05", deprecated=True),
-    MapVersion("Impossible_BossesReforgedV1.02", deprecated=True),
+    try:
+        message_info = lobby.to_discord_message_info()
+        if message_info is None:
+            logging.info("Lobby skipped: {}".format(lobby))
+            return
 
-    MapVersion("Impossible Bosses BetaV3V", deprecated=True),
-    MapVersion("Impossible Bosses BetaV3R", deprecated=True),
-    MapVersion("Impossible Bosses BetaV3P", deprecated=True),
-    MapVersion("Impossible Bosses BetaV3E", deprecated=True),
-    MapVersion("Impossible Bosses BetaV3C", deprecated=True),
-    MapVersion("Impossible Bosses BetaV3A", deprecated=True),
-    MapVersion("Impossible Bosses BetaV2X", deprecated=True),
-    MapVersion("Impossible Bosses BetaV2W", deprecated=True),
-    MapVersion("Impossible Bosses BetaV2S", deprecated=True),
-    MapVersion("Impossible Bosses BetaV2J", deprecated=True),
-    MapVersion("Impossible Bosses BetaV2F", deprecated=True),
-    MapVersion("Impossible Bosses BetaV2E", deprecated=True),
-    MapVersion("Impossible Bosses BetaV2D", deprecated=True),
-    MapVersion("Impossible Bosses BetaV2C", deprecated=True),
-    MapVersion("Impossible Bosses BetaV2A", deprecated=True),
-    MapVersion("Impossible Bosses BetaV1Y", deprecated=True),
-    MapVersion("Impossible Bosses BetaV1X", deprecated=True),
-    MapVersion("Impossible Bosses BetaV1W", deprecated=True),
-    MapVersion("Impossible Bosses BetaV1V", deprecated=True),
-    MapVersion("Impossible Bosses BetaV1R", deprecated=True),
-    MapVersion("Impossible Bosses BetaV1P", deprecated=True),
-    MapVersion("Impossible Bosses BetaV1C", deprecated=True),
-]
-
-def get_map_version(map_file):
-    for version in KNOWN_VERSIONS:
-        if map_file == version.file_name:
-            return version
-    return None
-
-def get_map_server_nice(server):
-    if server == "usw":
-        return ":flag_us: US"
-    elif server == "eu":
-        return ":flag_eu: EU"
-    elif server == "kr":
-        return ":flag_kr: KR"
-    elif server == "Montreal":
-        return ":flag_ca: Montreal (ENT)"
-    elif server == "New York":
-        return ":flag_us: New York (ENT)"
-    elif server == "France":
-        return ":flag_fr: France (ENT)"
-    elif server == "Amsterdam":
-        return ":flag_nl: Amsterdam (ENT)"
-    return server
-
-class Lobby:
-    def __init__(self, lobby_dict, is_ent):
-        self.is_ent = is_ent
-        self.id = lobby_dict["id"]
-        self.name = lobby_dict["name"]
-        self.map = lobby_dict["map"]
-        self.host = lobby_dict["host"]
-        self.subscribers = []
-
-        if is_ent:
-            self.server = lobby_dict["location"]
-            self.slots_taken = lobby_dict["slots_taken"]
-            self.slots_total = lobby_dict["slots_total"]
-        else:
-            if self.map[-4:] == ".w3x":
-                self.map = self.map[:-4]
-            self.server = lobby_dict["server"]
-            self.slots_taken = lobby_dict["slotsTaken"]
-            self.slots_total = lobby_dict["slotsTotal"]
-
-    def __eq__(self, other):
-        return self.id == other.id
-
-    def __hash__(self):
-        return self.id
-
-    def __str__(self):
-        return "[id={} ent={} name=\"{}\" server={} map=\"{}\" host={} slots={}/{} message_id={}]".format(
-            self.id, self.is_ent, self.name, self.server, self.map, self.host, self.slots_taken, self.slots_total, self.get_message_id()
+        logging.info("Creating lobby: {}".format(lobby))
+        key = lobby.get_message_id_key()
+        await ensure_display(send_message_with_bell_reactions,
+            channel, content=message_info["message"], embed=message_info["embed"],
+            window=ENSURE_DISPLAY_WINDOW, return_name=key
         )
+    except Exception as e:
+        logging.error("Failed to send message for lobby \"{}\", {}".format(lobby, e))
+        traceback.print_exc()
 
-    def is_ib(self):
-        #return self.map.find("Legion") != -1 and self.map.find("TD") != -1 # test
-        #return self.map.find("Uther Party") != -1 # test
-        return self.map.find("Impossible") != -1 and self.map.find("Bosses") != -1
+async def lobby_update_message(lobby, is_open=True):
+    channel = _ent_channel if lobby.is_ent else _bnet_channel
 
-    def get_message_id_key(self):
-        return "lobbymsg{}".format(self.id)
-
-    def get_message_id(self):
-        key = self.get_message_id_key()
-        if key not in globals():
-            return None
-        return globals()[key]
-
-    def is_updated(self, new):
-        return self.name != new.name or self.server != new.server or self.map != new.map or self.host != new.host or self.slots_taken != new.slots_taken or self.slots_total != new.slots_total
-
-    def to_discord_message_info(self, open=True):
-        COLOR_CLOSED = discord.Colour(0x8a0808)
-
-        version = get_map_version(self.map)
-        mark = ""
-        message = ""
-        if version is None:
-            mark = ":question:"
-            message = ":warning: *WARNING: Unknown map version* :warning:"
-        elif version.counterfeit:
-            mark = ":x:"
-            message = ":warning: *WARNING: Counterfeit version* :warning:"
-        elif not self.is_ent and version.ent_only:
-            mark = ":x:"
-            message = ":warning: *WARNING: Incompatible version* :warning:"
-        elif version.deprecated:
-            mark = ":x:"
-            message = ":warning: *WARNING: Old map version* :warning:"
-
-        slots_taken = self.slots_taken
-        slots_total = self.slots_total
-
-        if version is not None:
-            if not self.is_ent:
-                # Not sure why, but IB bnet lobbies have 1 extra slot
-                slots_taken -= 1
-                slots_total -= 1
-
-            if slots_total not in version.slots:
-                logging.error("Invalid total slots {}, expected {}, for map file {}".format(self.slots_total, version.slots, self.map))
-                return None
-
-        title_format = "{} ({}/{})"
-        description_format = "{} {}"
-        if not open:
-            title_format = "~~{}~~ ({}/{})"
-            description_format = "~~{}~~ {}"
-
-        title = title_format.format(self.name, slots_taken, slots_total)
-        description = description_format.format(self.map, mark)
-        host = self.host if len(self.host) > 0 else "---"
-        server = get_map_server_nice(self.server)
-
-        embed = discord.Embed(title=title, description=description)
-        embed.add_field(name="Host", value=host, inline=True)
-        embed.add_field(name="Server", value=server, inline=True)
-        if len(self.subscribers) > 0:
-            subscribers_string = BELL_EMOJI + " "
-            for i in range(0, len(self.subscribers), 4):
-                if i != 0:
-                    subscribers_string += "\n"
-                subscribers_string += ", ".join([
-                    sub.display_name for sub in self.subscribers[i:i+4]
-                ])
-
-            embed.set_footer(text=subscribers_string)
-
-        if not open:
-            embed.color = COLOR_CLOSED
-
-        return {
-            "message": message,
-            "embed": embed,
-        }
-
-    async def create_message(self):
-        channel = _ent_channel if self.is_ent else _bnet_channel
-
+    message_id = lobby_get_message_id(lobby)
+    if message_id is not None:
+        message = None
         try:
-            message_info = self.to_discord_message_info()
-            if message_info is None:
-                logging.info("Lobby skipped: {}".format(self))
-                return
-
-            logging.info("Creating lobby: {}".format(self))
-            key = self.get_message_id_key()
-            await ensure_display(send_message_with_bell_reactions,
-                channel, content=message_info["message"], embed=message_info["embed"],
-                window=ENSURE_DISPLAY_WINDOW, return_name=key
-            )
+            message = await channel.fetch_message(message_id)
         except Exception as e:
-            logging.error("Failed to send message for lobby \"{}\", {}".format(self, e))
+            logging.error("Error fetching message with ID {}, {}".format(message_id, e))
             traceback.print_exc()
 
-    async def update_message(self, is_open=True):
-        channel = _ent_channel if self.is_ent else _bnet_channel
-
-        message_id = self.get_message_id()
-        if message_id is not None:
-            message = None
+        if message is not None:
             try:
-                message = await channel.fetch_message(message_id)
-            except Exception as e:
-                logging.error("Error fetching message with ID {}, {}".format(message_id, e))
-                traceback.print_exc()
-
-            if message is not None:
-                try:
-                    message_info = self.to_discord_message_info(is_open)
-                    if message_info is None:
-                        logging.info("Lobby skipped: {}".format(self))
-                        return
-                except Exception as e:
-                    logging.error("Failed to get lobby as message info for \"{}\", {}".format(
-                        self.name, e
-                    ))
-                    traceback.print_exc()
+                message_info = lobby.to_discord_message_info(is_open)
+                if message_info is None:
+                    logging.info("Lobby skipped: {}".format(lobby))
                     return
-
-                logging.info("Updating lobby (open={}): {}".format(is_open, self))
-                await ensure_display(message.edit, content=message_info["message"], embed=message_info["embed"], window=ENSURE_DISPLAY_WINDOW)
-        else:
-            logging.error("Missing message ID on update for lobby {}".format(self))
-
-        if not is_open:
-            if len(self.subscribers) > 0:
-                logging.info("Lobby closed, notifying {} subscribers".format(len(self.subscribers)))
-                subscribers_string = "Lobby started/unhosted: **{}**\n".format(self.name)
-                subscribers_string += ", ".join([sub.mention for sub in self.subscribers])
-                await ensure_display(channel.send, subscribers_string)
-
-            key = self.get_message_id_key()
-            if key in globals():
-                del globals()[key]
-
-    async def delete_message(self):
-        channel = _ent_channel if self.is_ent else _bnet_channel
-
-        message_id = self.get_message_id()
-        if message_id is not None:
-            message = None
-            try:
-                message = await channel.fetch_message(message_id)
             except Exception as e:
-                logging.error("Error fetching message with ID {}, {}".format(message_id, e))
+                logging.error("Failed to get lobby as message info for \"{}\", {}".format(
+                    lobby.name, e
+                ))
                 traceback.print_exc()
+                return
 
-            if message is not None:
-                await ensure_display(message.delete, window=ENSURE_DISPLAY_WINDOW)
-        else:
-            logging.error("Missing message ID on delete for lobby {}".format(self))
+            logging.info("Updating lobby (open={}): {}".format(is_open, lobby))
+            await ensure_display(message.edit, content=message_info["message"], embed=message_info["embed"], window=ENSURE_DISPLAY_WINDOW)
+    else:
+        logging.error("Missing message ID on update for lobby {}".format(lobby))
 
-        key = self.get_message_id_key()
+    if not is_open:
+        if len(lobby.subscribers) > 0:
+            logging.info("Lobby closed, notifying {} subscribers".format(len(lobby.subscribers)))
+            subscribers_string = "Lobby started/unhosted: **{}**\n".format(lobby.name)
+            subscribers_string += ", ".join([sub.mention for sub in lobby.subscribers])
+            await ensure_display(channel.send, subscribers_string)
+
+        key = lobby.get_message_id_key()
         if key in globals():
             del globals()[key]
+
+async def lobby_delete_message(lobby):
+    channel = _ent_channel if lobby.is_ent else _bnet_channel
+
+    message_id = lobby_get_message_id(lobby)
+    if message_id is not None:
+        message = None
+        try:
+            message = await channel.fetch_message(message_id)
+        except Exception as e:
+            logging.error("Error fetching message with ID {}, {}".format(message_id, e))
+            traceback.print_exc()
+
+        if message is not None:
+            await ensure_display(message.delete, window=ENSURE_DISPLAY_WINDOW)
+    else:
+        logging.error("Missing message ID on delete for lobby {}".format(lobby))
+
+    key = lobby.get_message_id_key()
+    if key in globals():
+        del globals()[key]
 
 def get_lobby_changes(prev_lobbies, api_lobbies):
     lobbies = []
@@ -1248,15 +1073,15 @@ async def report_lobbies(prev_lobbies, api_lobbies):
     # Update messages for closed lobbies
     for i in range(len(prev_lobbies)):
         if changes[1][i]:
-            await prev_lobbies[i].update_message(is_open=False)
+            await lobby_update_message(prev_lobbies[i], is_open=False)
 
     # Create/update messages for open lobbies
     for i in range(len(lobbies)):
         assert not (changes[2][i] and changes[3][i])
         if changes[2][i]:
-            await lobbies[i].create_message()
+            await lobby_create_message(lobbies[i])
         if changes[3][i]:
-            await lobbies[i].update_message()
+            await lobby_update_message(lobbies[i])
 
     return lobbies
 
@@ -1334,30 +1159,26 @@ async def update_ib_lobbies():
 
     _open_lobbies = new_bnet_lobbies + new_ent_lobbies
 
-# TODO temporary, to support "!getgames"
-async def do_getgames(channel, getgames_message):
+@_client.command()
+async def getgames(ctx):
     global _open_lobbies
 
-    if channel == _ent_channel:
+    if ctx.channel == _ent_channel:
         is_ent_channel = True
-    elif channel == _bnet_channel:
+    elif ctx.channel == _bnet_channel:
         is_ent_channel = False
     else:
         return
-    await ensure_display(getgames_message.delete)
+    await ensure_display(ctx.message.delete)
 
     async with _update_lobbies_lock:
         # Clear all posted messages for open lobbies and trigger a refresh
         for lobby in _open_lobbies:
             if lobby.is_ent == is_ent_channel:
-                await lobby.delete_message()
+                await lobby_delete_message(lobby)
 
         _open_lobbies = [lobby for lobby in _open_lobbies if lobby.is_ent != is_ent_channel]
         await update_ib_lobbies()
-
-@_client.command()
-async def getgames(ctx):
-    await do_getgames(ctx.channel, ctx.message)
 
 @loop(seconds=LOBBY_REFRESH_RATE)
 async def refresh_ib_lobbies():
@@ -1375,7 +1196,7 @@ async def lobbies_on_reaction_add(reaction, user):
     match_lobby = False
     async with _update_lobbies_lock:
         for lobby in _open_lobbies:
-            message_id = lobby.get_message_id()
+            message_id = lobby_get_message_id(lobby)
             if reaction.message.id == message_id:
                 match_lobby = True
                 updated = False
@@ -1389,7 +1210,7 @@ async def lobbies_on_reaction_add(reaction, user):
                     updated = True
 
                 if updated:
-                    await lobby.update_message()
+                    await lobby_update_message(lobby)
 
     if match_lobby:
         await ensure_display(reaction.remove, user)

--- a/replays.py
+++ b/replays.py
@@ -126,7 +126,11 @@ class ReplayData:
             elif difficulty != difficulty_player:
                 raise ValueError("Inconsistent difficulties: {} and {}".format(difficulty, difficulty_player))
 
-            continues_player = player["variables"]["contines"]
+            if "contines" in player["variables"]:
+                # I had a typo in the IB map...
+                continues_player = player["variables"]["contines"]
+            else:
+                continues_player = player["variables"]["continues"]
             if continues == None:
                 continues = continues_player
             elif continues != continues_player:

--- a/replays.py
+++ b/replays.py
@@ -70,7 +70,11 @@ class PlayerStats:
         self.dmg = json["damage"]
         self.hl = json["healing"]
         self.hlr = json["healingReceived"]
-        self.hlrSw = json["sWHealingReceived"]
+        if "sWHealingReceived" not in json:
+            # Data completeness issue
+            self.hlrSw = None
+        else:
+            self.hlrSw = json["sWHealingReceived"]
         self.degen = json["degen"]
 
 class PlayerData:
@@ -111,14 +115,12 @@ class ReplayData:
         difficulty = None
         continues = None
         for player in game["players"]:
-            if len(player["flags"]) != 1:
-                raise ValueError("{} flags for player, expected 1: {}".format(len(player["flags"]), player))
-
-            flag_player = player["flags"][0]
-            if flag == None:
-                flag = flag_player
-            elif flag != flag_player:
-                raise ValueError("Inconsistent flags: {} and {}".format(flag, flag_player))
+            if len(player["flags"]) == 1:
+                flag_player = player["flags"][0]
+                if flag == None:
+                    flag = flag_player
+                elif flag != flag_player:
+                    raise ValueError("Inconsistent flags: {} and {}".format(flag, flag_player))
 
             difficulty_player = player["variables"]["difficulty"]
             if difficulty == None:
@@ -140,6 +142,8 @@ class ReplayData:
             self.win = True
         elif flag == "loser":
             self.win = False
+        elif flag == None:
+            raise ValueError("No flag values found")
         else:
             raise ValueError("Invalid flag: {}".format(flag))
 

--- a/replays.py
+++ b/replays.py
@@ -1,0 +1,118 @@
+from enum import Enum, unique
+
+@unique
+class Difficulty(Enum):
+    VERY_EASY = "Very Easy"
+    EASY = "Easy"
+    MODERATE = "Moderate"
+    NORMAL = "Normal"
+    HARD = "Hard"
+
+@unique
+class Class(Enum):
+    DEATH_KNIGHT = "Death Knight"
+    DRUID = "Druid"
+    FIRE_MAGE = "Fire Mage"
+    ICE_MAGE = "Ice Mage"
+    PALADIN = "Paladin"
+    PRIEST = "Priest"
+    RANGER = "Ranger"
+    ROGUE = "Rogue"
+    WARLOCK = "Warlock"
+    WARRIOR = "Warrior"
+
+@unique
+class Boss(Enum):
+    FIRE = "fire"
+    WATER = "water"
+    BRUTE = "brute"
+    THUNDER = "thunder"
+    DRUID = "druid"
+    SHADOW = "shadow"
+    ICE = "ice"
+    LIGHT = "light"
+    ANCIENT = "ancient"
+    DEMONIC = "demonic"
+
+class PlayerStats:
+    def __init__(self, json):
+        self.deaths = json["deaths"]
+        self.dmg = json["damage"]
+        self.hl = json["healing"]
+        self.hlr = json["healingReceived"]
+        self.hlrSw = json["sWHealingReceived"]
+        self.degen = json["degen"]
+
+class PlayerData:
+    def __init__(self, json):
+        self.name = json["name"]
+        self.is_host = json["isHost"]
+        self.slot = json["slot"]
+        self.color = json["colour"]
+        mmd_vars = json["variables"]
+        self.class_ = Class(mmd_vars["class"])
+        self.health = mmd_vars["health"]
+        self.mana = mmd_vars["mana"]
+        self.ability = mmd_vars["ability"]
+        self.ms = mmd_vars["movementSpeed"]
+        self.coins = mmd_vars["coins"]
+        self.stats_overall = PlayerStats(mmd_vars)
+        self.stats_boss = {}
+        for boss in Boss:
+            mmd_vars_boss = {}
+            for k, v in mmd_vars.items():
+                if k[:len(boss.value)] == boss.value:
+                    k_trim = k[len(boss.value):]
+                    if len(k_trim) > 0:
+                        k_trim[0] = lower(k_trim[0])
+                        mmd_vars_boss[k_trim] = v
+            self.stats_boss[boss] = PlayerStats(mmd_vars_boss)
+
+class ReplayData:
+    def __init__(self, json):
+        game = json["body"]["data"]["game"]
+        self.id = json["body"]["id"]
+        self.game_name = game["name"]
+        self.map = game["map"]
+        self.host = game["host"]
+        self.players = [PlayerData(player) for player in game["players"]]
+        flag = None
+        difficulty = None
+        continues = None
+        for player in game["players"]:
+            if len(player["flags"]) != 1:
+                raise ValueError("more than 1 flag for player: {}".format(player))
+
+            flag_player = player["flags"][0]
+            if flag == None:
+                flag = flag_player
+            elif flag != flag_player:
+                raise ValueError("Inconsistent flags: {} and {}".format(flag, flag_player))
+
+            difficulty_player = player["variables"]["difficulty"]
+            if difficulty == None:
+                difficulty = difficulty_player
+            elif difficulty != difficulty_player:
+                raise ValueError("Inconsistent difficulties: {} and {}".format(difficulty, difficulty_player))
+
+            continues_player = player["variables"]["continues"]
+            if continues == None:
+                continues = continues_player
+            elif continues != continues_player:
+                raise ValueError("Inconsistent difficulties: {} and {}".format(continues, continues_player))
+
+        if flag == "winner":
+            self.win = True
+        elif flag == "loser":
+            self.win = False
+        else:
+            raise ValueError("Invalid flag: {}".format(flag))
+
+        self.difficulty = Difficulty(difficulty)
+
+        if continues == "yes":
+            self.continues = True
+        elif continues == "no":
+            self.continues = False
+        else:
+            raise ValueError("Invalid continues: {}".format(continues))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp
 discord.py
 gitpython
+pytest
 requests

--- a/test_replays.py
+++ b/test_replays.py
@@ -1,0 +1,53 @@
+import pytest
+import requests
+
+from replays import ReplayData, Difficulty
+
+class TestCaseWc3Stats:
+	def __init__(self, replay_id, map_file, difficulty, continues, win):
+		self.replay_id = replay_id
+		self.map_file = map_file
+		self.difficulty = difficulty
+		self.continues = continues
+		self.win = win
+
+@pytest.mark.parametrize("test_case", [
+	TestCaseWc3Stats(
+		99971,
+		"Impossible.Bosses.v1.11.4-nobnet",
+		Difficulty.N,
+		continues=True,
+		win=False
+	),
+	TestCaseWc3Stats(
+		100502,
+		"Impossible.Bosses.v1.11.4-nobnet",
+		Difficulty.N,
+		continues=True,
+		win=True
+	),
+	TestCaseWc3Stats(
+		100713,
+		"Impossible.Bosses.v1.11.5-no-bnet",
+		Difficulty.N,
+		continues=True,
+		win=True
+	),
+	TestCaseWc3Stats(
+		100995,
+		"Impossible.Bosses.v1.11.5-no-bnet",
+		Difficulty.H,
+		continues=True,
+		win=True
+	)
+])
+def test_wc3stats_replay(test_case):
+	r = requests.get("https://api.wc3stats.com/replays/{}".format(test_case.replay_id))
+	assert r.status_code == 200
+	data = ReplayData(r.json())
+
+	assert data.id == test_case.replay_id
+	assert data.map == test_case.map_file
+	assert data.difficulty == test_case.difficulty
+	assert data.continues == test_case.continues
+	assert data.win == test_case.win

--- a/test_replays.py
+++ b/test_replays.py
@@ -44,8 +44,8 @@ class TestCaseWc3Stats:
 def test_wc3stats_replay(test_case):
 	r = requests.get("https://api.wc3stats.com/replays/{}".format(test_case.replay_id))
 	assert r.status_code == 200
-	data = ReplayData(r.json())
 
+	data = ReplayData(r.json())
 	assert data.id == test_case.replay_id
 	assert data.map == test_case.map_file
 	assert data.difficulty == test_case.difficulty


### PR DESCRIPTION
Felt inspired today. Several changes, much to review!
1. Added a new file `replays.py` dedicated to parsing out wc3stats replay data, based on the JSON format of its responses [like this one](https://api.wc3stats.com/replays/99971). Will be fun to play around with in the future. For now, I used it to generate a nicer display of an uploaded replay. 
2. Split off the more "standalone" part of the lobbies code into a new file, `lobbies.py`. `main.py` was starting to feel really crowded, and the split worked a lot better than I expected.
3. Removed an old code path for handling `!getgames`. This is from back when I was hosting IB Lobbies and didn't want to use the `!` command prefix.
4. Added test code in `test_replays.py` to fetch and parse a few example replay files, just to make sure that doesn't break. Tests can be run with `python -m pytest`, after you've installed pytest module. This isn't used in the live bot, so **no need to install this in our Pi hosts**.
5. Added a `.github/workflows/main.yaml` file that will run tests on my Pi for every PR and when code is merged. Still nothing that affects the live bot.

Example of uploaded replay message from `#test_bot` channel:

![example](https://user-images.githubusercontent.com/11249051/111580489-fa098b00-878d-11eb-81b2-570addb7daeb.png)

Also, these diff view settings might make the review easier:
![rev](https://user-images.githubusercontent.com/11249051/111580420-dd6d5300-878d-11eb-9fa2-4adb71e0af60.png)
