### PR TITLE
Some replay parsing fixes

### DIFF
--- a/replays.py
+++ b/replays.py
@@ -117,14 +117,18 @@ class ReplayData:
         for player in game["players"]:
             if len(player["flags"]) == 1:
                 flag_player = player["flags"][0]
-                if flag == None:
+                if flag is None:
                     flag = flag_player
+                elif flag_player is None:
+                    continue
                 elif flag != flag_player:
                     raise ValueError("Inconsistent flags: {} and {}".format(flag, flag_player))
 
             difficulty_player = player["variables"]["difficulty"]
-            if difficulty == None:
+            if difficulty is None:
                 difficulty = difficulty_player
+            elif difficulty_player is None:
+                continue
             elif difficulty != difficulty_player:
                 raise ValueError("Inconsistent difficulties: {} and {}".format(difficulty, difficulty_player))
 
@@ -133,16 +137,18 @@ class ReplayData:
                 continues_player = player["variables"]["contines"]
             else:
                 continues_player = player["variables"]["continues"]
-            if continues == None:
+            if continues is None:
                 continues = continues_player
+            elif continues_player is None:
+                continue
             elif continues != continues_player:
                 raise ValueError("Inconsistent difficulties: {} and {}".format(continues, continues_player))
 
         if flag == "winner":
             self.win = True
-        elif flag == "loser":
+        elif flag == "loser" or flag is None:
             self.win = False
-        elif flag == None:
+        elif flag is None:
             raise ValueError("No flag values found")
         else:
             raise ValueError("Invalid flag: {}".format(flag))
@@ -156,7 +162,12 @@ class ReplayData:
         else:
             raise ValueError("Invalid continues: {}".format(continues))
 
-        self.players = [PlayerData(p) for p in game["players"]]
+        self.players = []
+        for p in game["players"]:
+            try:
+                self.players.append(PlayerData(p))
+            except ValueError:
+                continue
         self.boss_kills = None
         if not self.win:
             self.boss_kills = max([p.boss_kills for p in self.players])

--- a/test/test_replays.py
+++ b/test/test_replays.py
@@ -3,7 +3,7 @@ import requests
 
 from replays import ReplayData, Difficulty
 
-class TestCaseWc3Stats:
+class CaseWc3Stats:
 	def __init__(self, replay_id, map_file, difficulty, continues, win):
 		self.replay_id = replay_id
 		self.map_file = map_file
@@ -12,30 +12,72 @@ class TestCaseWc3Stats:
 		self.win = win
 
 @pytest.mark.parametrize("test_case", [
-	TestCaseWc3Stats(
+	CaseWc3Stats(
 		99971,
 		"Impossible.Bosses.v1.11.4-nobnet",
 		Difficulty.N,
 		continues=True,
 		win=False
 	),
-	TestCaseWc3Stats(
+	CaseWc3Stats(
 		100502,
 		"Impossible.Bosses.v1.11.4-nobnet",
 		Difficulty.N,
 		continues=True,
 		win=True
 	),
-	TestCaseWc3Stats(
+	CaseWc3Stats(
 		100713,
 		"Impossible.Bosses.v1.11.5-no-bnet",
 		Difficulty.N,
 		continues=True,
 		win=True
 	),
-	TestCaseWc3Stats(
+	CaseWc3Stats(
 		100995,
 		"Impossible.Bosses.v1.11.5-no-bnet",
+		Difficulty.H,
+		continues=True,
+		win=True
+	),
+	CaseWc3Stats(
+		101252,
+		"Impossible.Bosses.v1.11.5-no-bnet",
+		Difficulty.H,
+		continues=True,
+		win=True
+	),
+	CaseWc3Stats(
+		101359,
+		"Impossible.Bosses.v1.11.5-no-bnet",
+		Difficulty.N,
+		continues=True,
+		win=False
+	),
+	CaseWc3Stats(
+		101527,
+		"Impossible.Bosses.v1.11.6-no-bnet",
+		Difficulty.H,
+		continues=True,
+		win=True
+	),
+	CaseWc3Stats(
+		101870,
+		"Impossible.Bosses.v1.11.6",
+		Difficulty.E,
+		continues=True,
+		win=False
+	),
+	CaseWc3Stats(
+		101888,
+		"Impossible.Bosses.v1.11.6",
+		Difficulty.E,
+		continues=True,
+		win=True
+	),
+	CaseWc3Stats(
+		101939,
+		"Impossible.Bosses.v1.11.6-no-bnet",
 		Difficulty.H,
 		continues=True,
 		win=True

--- a/test/test_replays.py
+++ b/test/test_replays.py
@@ -81,6 +81,13 @@ class CaseWc3Stats:
 		Difficulty.H,
 		continues=True,
 		win=True
+	),
+	CaseWc3Stats(
+		105240,
+		"Impossible.Bosses.v1.11.6-no-bnet",
+		Difficulty.H,
+		continues=True,
+		win=True
 	)
 ])
 def test_wc3stats_replay(test_case):


### PR DESCRIPTION
Replays with observers or otherwise incomplete player data would fail to parse, so they wouldn't display the nice player list / results. Should be fixed for most cases.